### PR TITLE
feat: add support for day strings

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -264,6 +264,12 @@ func processField(value string, field reflect.Value) error {
 		)
 		if field.Kind() == reflect.Int64 && typ.PkgPath() == "time" && typ.Name() == "Duration" {
 			var d time.Duration
+
+			// time.Parse does not support day durations, so we convert any day durations to an hours string
+			if newValue, changed := daysToHoursDurationStr(value); changed {
+				value = newValue
+			}
+
 			d, err = time.ParseDuration(value)
 			val = int64(d)
 		} else {
@@ -374,4 +380,19 @@ func binaryUnmarshaler(field reflect.Value) (b encoding.BinaryUnmarshaler) {
 func isTrue(s string) bool {
 	b, _ := strconv.ParseBool(s)
 	return b
+}
+
+// daysToHoursDurationStr attempts to convert a day duration string to an hours duration string
+//
+//	if it succeeds it returns the new string and indicates it was changed, otherwise it returns the original
+func daysToHoursDurationStr(s string) (string, bool) {
+	pattern := `^\d+d$`
+	matched, _ := regexp.MatchString(pattern, s)
+
+	if matched {
+		day, _ := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		return fmt.Sprintf("%dh", day*24), true
+	}
+
+	return s, false
 }

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -591,6 +591,51 @@ func TestEmbeddedStruct(t *testing.T) {
 	}
 }
 
+func TestIsDayDuration(t *testing.T) {
+	tests := []struct {
+		duration      string
+		expectConvert bool
+		hourString    string
+	}{
+		/* Return converted value, since they are day strings */
+		{"1d", true, "24h"},
+		{"10d", true, "240h"},
+		{"100d", true, "2400h"},
+		{"1000d", true, "24000h"},
+		{"30d", true, "720h"},
+
+		/* Return original value since they are not day strings */
+		{"1h", false, "1h"},
+		{"1m", false, "1m"},
+		{"d", false, "d"},
+		{"1", false, "1"},
+		{"1dd", false, "1dd"},
+	}
+
+	for _, d := range tests {
+		if newValue, ok := daysToHoursDurationStr(d.duration); ok != d.expectConvert {
+			t.Errorf("unexpected conversion result: %v", ok)
+		} else {
+			if newValue != d.hourString {
+				t.Errorf("expected %s, got %s", d.hourString, newValue)
+			}
+		}
+	}
+}
+func TestHourDuration(t *testing.T) {
+	var s struct {
+		ADayString time.Duration `envconfig:"DAYS" default:"10d"`
+	}
+
+	if err := Process("env_config", &s); err != nil {
+		t.Error(err.Error())
+	}
+
+	if s.ADayString != 10*24*time.Hour {
+		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.ADayString)
+	}
+}
+
 func TestEmbeddedButIgnoredStruct(t *testing.T) {
 	var s Specification
 	os.Clearenv()

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -594,7 +594,7 @@ func TestEmbeddedStruct(t *testing.T) {
 func TestDayDuration(t *testing.T) {
 	var s struct {
 		Days0  time.Duration `envconfig:"DAYS_0" default:"0d"`
-		Day1   time.Duration `envconfig:"DAYS_1" default:"1d"`
+		Days1  time.Duration `envconfig:"DAYS_1" default:"1d"`
 		Days10 time.Duration `envconfig:"DAYS_10" default:"10d"`
 	}
 
@@ -607,10 +607,10 @@ func TestDayDuration(t *testing.T) {
 	}
 
 	if s.Days10 != 10*24*time.Hour {
-		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.Day1)
+		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.Days1)
 	}
 
-	if s.Day1 != 1*24*time.Hour {
+	if s.Days1 != 1*24*time.Hour {
 		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.Days10)
 	}
 }

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -591,48 +591,47 @@ func TestEmbeddedStruct(t *testing.T) {
 	}
 }
 
-func TestIsDayDuration(t *testing.T) {
-	tests := []struct {
-		duration      string
-		expectConvert bool
-		hourString    string
-	}{
-		/* Return converted value, since they are day strings */
-		{"1d", true, "24h"},
-		{"10d", true, "240h"},
-		{"100d", true, "2400h"},
-		{"1000d", true, "24000h"},
-		{"30d", true, "720h"},
-
-		/* Return original value since they are not day strings */
-		{"1h", false, "1h"},
-		{"1m", false, "1m"},
-		{"d", false, "d"},
-		{"1", false, "1"},
-		{"1dd", false, "1dd"},
-	}
-
-	for _, d := range tests {
-		if newValue, ok := daysToHoursDurationStr(d.duration); ok != d.expectConvert {
-			t.Errorf("unexpected conversion result: %v", ok)
-		} else {
-			if newValue != d.hourString {
-				t.Errorf("expected %s, got %s", d.hourString, newValue)
-			}
-		}
-	}
-}
-func TestHourDuration(t *testing.T) {
+func TestDayDuration(t *testing.T) {
 	var s struct {
-		ADayString time.Duration `envconfig:"DAYS" default:"10d"`
+		Days0  time.Duration `envconfig:"DAYS_0" default:"0d"`
+		Day1   time.Duration `envconfig:"DAYS_1" default:"1d"`
+		Days10 time.Duration `envconfig:"DAYS_10" default:"10d"`
 	}
 
 	if err := Process("env_config", &s); err != nil {
 		t.Error(err.Error())
 	}
 
-	if s.ADayString != 10*24*time.Hour {
-		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.ADayString)
+	if s.Days0 != 0 {
+		t.Errorf("expected %d, got %s", 0, s.Days0)
+	}
+
+	if s.Days10 != 10*24*time.Hour {
+		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.Day1)
+	}
+
+	if s.Day1 != 1*24*time.Hour {
+		t.Errorf("expected %s, got %s", 10*24*time.Hour, s.Days10)
+	}
+}
+
+func TestInvalidDayDuration(t *testing.T) {
+
+	badDays := []string{
+		"1dd",
+		"d",
+		" d",
+	}
+
+	for _, badDay := range badDays {
+		var s Specification
+		os.Clearenv()
+		os.Setenv("ENV_CONFIG_TIMEOUT", badDay)
+		err := Process("env_config", &s)
+
+		if err == nil {
+			t.Errorf("expected an err!")
+		}
 	}
 }
 


### PR DESCRIPTION
This change makes it possible to add day time.Durations such as
"30d".

This isn't supported out of the box becase time.ParseDuration doesn't
support days.
