### PR TITLE
chore(doc): fix use semicolon not comma as map separator in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export MYAPP_USER=Kelsey
 export MYAPP_RATE="0.5"
 export MYAPP_TIMEOUT="3m"
 export MYAPP_USERS="rob,ken,robert"
-export MYAPP_COLORCODES="red:1,green:2,blue:3"
+export MYAPP_COLORCODES="red:1;green:2;blue:3"
 ```
 
 Write some code:
@@ -144,7 +144,7 @@ If envconfig can't find an environment variable value for `MYAPP_DEFAULTVAR`,
 it will populate it with "foobar" as a default value.
 
 If envconfig can't find an environment variable value for `MYAPP_REQUIREDVAR`,
-it will return an error when asked to process the struct.  If
+it will return an error when asked to process the struct. If
 `MYAPP_REQUIREDVAR` is present but empty, envconfig will not return an error.
 
 If envconfig can't find an environment variable in the form `PREFIX_MYVAR`, and there
@@ -155,6 +155,7 @@ variable that directly matches the envconfig tag in your struct definition:
 export SERVICE_HOST=127.0.0.1
 export MYAPP_DEBUG=true
 ```
+
 ```Go
 type Specification struct {
     ServiceHost string `envconfig:"SERVICE_HOST"`
@@ -169,15 +170,15 @@ environment variable is set.
 
 envconfig supports these struct field types:
 
-  * string
-  * int8, int16, int32, int64
-  * bool
-  * float32, float64
-  * slices of any supported type
-  * maps (keys and values of any supported type)
-  * [encoding.TextUnmarshaler](https://golang.org/pkg/encoding/#TextUnmarshaler)
-  * [encoding.BinaryUnmarshaler](https://golang.org/pkg/encoding/#BinaryUnmarshaler)
-  * [time.Duration](https://golang.org/pkg/time/#Duration)
+- string
+- int8, int16, int32, int64
+- bool
+- float32, float64
+- slices of any supported type
+- maps (keys and values of any supported type)
+- [encoding.TextUnmarshaler](https://golang.org/pkg/encoding/#TextUnmarshaler)
+- [encoding.BinaryUnmarshaler](https://golang.org/pkg/encoding/#BinaryUnmarshaler)
+- [time.Duration](https://golang.org/pkg/time/#Duration)
 
 Embedded structs using these fields are also supported.
 


### PR DESCRIPTION
remarkable fork uses semicolon not comma as map separator
reflect this in example usage