### PR TITLE
feat(types): add the raw id to the pubsub topic

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -220,6 +220,10 @@ func TestProcess(t *testing.T) {
 		t.Errorf("expected %q, got %q", u, s.UrlPointer.Value.String())
 	}
 
+	if s.GooglePubSubTopic.ID != "projects/project-id/topics/topic-id" {
+		t.Errorf("expected %s, got %s", "projects/project-id/topics/topic-id", s.GooglePubSubTopic.ID)
+	}
+
 	if s.GooglePubSubTopic.ProjectID != "project-id" {
 		t.Errorf("expected %s, got %s", "project-id", s.GooglePubSubTopic.ProjectID)
 	}

--- a/types/google.go
+++ b/types/google.go
@@ -17,6 +17,7 @@ var (
 )
 
 type GooglePubSubTopic struct {
+	ID        string // The raw ID passed
 	ProjectID string
 	TopicID   string
 }
@@ -27,6 +28,7 @@ func (pst *GooglePubSubTopic) Set(value string) error {
 		return ErrInvalidGoogleTopicID
 	}
 
+	pst.ID = value
 	pst.ProjectID = m[1]
 	pst.TopicID = m[2]
 


### PR DESCRIPTION
The new pubsub library takes either the entire ID or just the topic name. This exposes the ID instead of having to recreate in the service